### PR TITLE
🔨 fix: return valid escaped ids

### DIFF
--- a/css-path.js
+++ b/css-path.js
@@ -35,7 +35,8 @@ var trim = require('trim')
         , id = elm.getAttribute('id')
 
       if (id) {
-        list.unshift(tag + '#' + trim(id))
+        var escapeSelector = function(selector) {return "".replace.call(selector,/(^[^_a-zA-Z\u00a0-\uffff]|[^-_a-zA-Z0-9\u00a0-\uffff])/g, "\\$1")};
+        list.unshift(tag + '#' + escapeSelector(trim(id)))
         return list
       }
 


### PR DESCRIPTION
<br>

✔ **Validating IDs**
<hr>

Escape any spaces or any unsupported characters of returned ids in order to be used safely with document.querySelector()
<br>
📜 **Example**
<hr>


👉 Input 

`div#this element has an id with spaces`

👈 Output

`div#this\ element\ has\ an\ id\ with\ spaces`
